### PR TITLE
Adjusted Chart to Display Percentages & Updated Scaling

### DIFF
--- a/app/components/Distribution.tsx
+++ b/app/components/Distribution.tsx
@@ -10,7 +10,6 @@ import useCourseData from "../hooks/useCourseData";
 import { compareGrades, getTermLongName } from "../utils";
 import { Loading } from "./Loading";
 import { Select } from "./Select";
-import { callback } from "chart.js/dist/helpers/helpers.core";
 
 type DistributionProps = {
   subjectArea: string;
@@ -83,9 +82,7 @@ const Distribution = ({ subjectArea, catalogNumber }: DistributionProps) => {
   const gradeCountsForInstructorNameForTerm =
     gradeCountsByInstructorNameByTerm?.[selectedInstructorName]?.[selectedTerm];
   const gradeCountArray = Object.values(gradeCountsForInstructorNameForTerm ?? {});
-  const totalGradeCountForInstructorNameForTerm = sum(
-    gradeCountArray.map(Number),
-  );
+  const totalGradeCountForInstructorNameForTerm = sum(gradeCountArray);
 
   const maxGradeCount = Math.max(...gradeCountArray);
 
@@ -176,6 +173,7 @@ const Distribution = ({ subjectArea, catalogNumber }: DistributionProps) => {
                   },
                   min: 0,
                   max: Math.min((15/14) * maxGradeCount, totalGradeCountForInstructorNameForTerm),
+                  //if one letter grade makes up over ~93% of total count keep 100% as the max; otherwise leave top-margin of 1/14th of max letter grade count for a cleaner chart layout
                 },
               },
             }}

--- a/app/components/Distribution.tsx
+++ b/app/components/Distribution.tsx
@@ -10,6 +10,7 @@ import useCourseData from "../hooks/useCourseData";
 import { compareGrades, getTermLongName } from "../utils";
 import { Loading } from "./Loading";
 import { Select } from "./Select";
+import { callback } from "chart.js/dist/helpers/helpers.core";
 
 type DistributionProps = {
   subjectArea: string;
@@ -81,9 +82,12 @@ const Distribution = ({ subjectArea, catalogNumber }: DistributionProps) => {
 
   const gradeCountsForInstructorNameForTerm =
     gradeCountsByInstructorNameByTerm?.[selectedInstructorName]?.[selectedTerm];
+  const gradeCountArray = Object.values(gradeCountsForInstructorNameForTerm ?? {});
   const totalGradeCountForInstructorNameForTerm = sum(
-    Object.values(gradeCountsForInstructorNameForTerm ?? {}).map(Number),
+    gradeCountArray.map(Number),
   );
+
+  const maxGradeCount = Math.max(...gradeCountArray);
 
   const chartData = Object.keys(gradeCountsForInstructorNameForTerm ?? {})
     .map((gradeOffered) => ({
@@ -150,10 +154,20 @@ const Distribution = ({ subjectArea, catalogNumber }: DistributionProps) => {
                 legend: {
                   display: false,
                 },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    const value = context.parsed.y;
+                    const pct = ((Number(value) / totalGradeCountForInstructorNameForTerm) * 100).toFixed(1);
+                    return `${value} (${pct}%)`
+                  }
+                }
+              }
               },
               scales: {
                 y: {
                   ticks: {
+                    count: 7,
                     callback: (value) => {
                       const decimal =
                         Number(value) / totalGradeCountForInstructorNameForTerm;
@@ -161,7 +175,7 @@ const Distribution = ({ subjectArea, catalogNumber }: DistributionProps) => {
                     },
                   },
                   min: 0,
-                  max: totalGradeCountForInstructorNameForTerm,
+                  max: Math.min((15/14) * maxGradeCount, totalGradeCountForInstructorNameForTerm),
                 },
               },
             }}


### PR DESCRIPTION
**Description**: Chart Tooltip now displays percentage, as well as number of students who received specified letter grade. Chart scaling is now dependent on the mode of the distribution (max grade count), rather than total grade count.

**Context**: I noticed that the chart would be mostly empty due to the chart's y-axis (percentage) going to 100% everytime, when in reality most classes will ever have at max ~40% of students receiving a certain grade. Instead of the y-axis being statically scaled to 100%, users would be able to much more quickly assess the chart with the y-axis being dynamically scaled to only accomodate the maximum grade count for a given letter grade. Morover, for bars in the middle of y-axis ticks, users would either have to approximate percentages, or find the total students in the class and do their own division. Rather, it would be much more convenient to give an exact percentage when a user hovers over a bar in the chart.

**Screenshots**: 

(Before Changes)
<img width="438" alt="Screenshot 2023-08-04 185835" src="https://github.com/nathanhleung/grades.natecation.xyz/assets/131506273/9db4ff6c-5fd7-4504-8c97-7757cba06836">


(After Changes)
<img width="438" alt="Screenshot 2023-08-04 185558" src="https://github.com/nathanhleung/grades.natecation.xyz/assets/131506273/aad2e12e-ffe2-41d2-996c-3c6cc1e102ad">

